### PR TITLE
Add Delta Lake setup, schema registry registration, and Glue Terraform config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.terraform/
+*.tfstate
+*.tfstate.backup
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# infodir
+# Data Lake Integration
+
+This repository demonstrates how to manage **curated** and **features** datasets
+using [Delta Lake](https://delta.io/). The tables are partitioned by
+`period=YYYY-MM` and optimized with Z-Ordering on the `term` column.
+
+## Components
+
+- `scripts/delta_setup.py` – creates Delta tables for curated and features data.
+- `scripts/register_schema.py` – registers Avro schemas in Confluent Schema Registry.
+- `terraform/` – Terraform configuration for Glue databases, tables and minimal IAM role.
+- `schemas/` – Avro schema contracts for each dataset.
+
+## Usage
+
+### Delta tables
+
+```bash
+python scripts/delta_setup.py
+```
+
+### Schema Registry
+
+```bash
+python scripts/register_schema.py
+```
+
+### Terraform
+
+```bash
+cd terraform
+terraform init -backend=false
+terraform apply
+```
+
+These examples use placeholder paths and URLs; adapt them to your environment.

--- a/schemas/curated.avsc
+++ b/schemas/curated.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "name": "CuratedRecord",
+  "namespace": "example",
+  "fields": [
+    {"name": "term", "type": "string"},
+    {"name": "period", "type": "string"},
+    {"name": "value", "type": "int"}
+  ]
+}

--- a/schemas/features.avsc
+++ b/schemas/features.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "name": "FeaturesRecord",
+  "namespace": "example",
+  "fields": [
+    {"name": "term", "type": "string"},
+    {"name": "period", "type": "string"},
+    {"name": "feature_value", "type": "double"}
+  ]
+}

--- a/scripts/delta_setup.py
+++ b/scripts/delta_setup.py
@@ -1,0 +1,56 @@
+"""Create Delta Lake tables for curated and features datasets.
+
+The script writes sample data to Delta format partitioned by period (YYYY-MM) and
+applies Z-Ordering by the ``term`` column. Paths and table names are provided as
+function arguments for reuse in different environments.
+"""
+from pyspark.sql import SparkSession
+
+
+def create_table(table_name: str, path: str) -> None:
+    """Create a Delta table with period partitioning and Z-Order by term.
+
+    Parameters
+    ----------
+    table_name:
+        Name of the table to register in the metastore.
+    path:
+        Storage location for the Delta table.
+    """
+    spark = (
+        SparkSession.builder.appName("DeltaSetup")
+        .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
+        .config(
+            "spark.sql.catalog.spark_catalog",
+            "org.apache.spark.sql.delta.catalog.DeltaCatalog",
+        )
+        .getOrCreate()
+    )
+
+    data = [
+        ("alpha", "2024-01", 1),
+        ("beta", "2024-02", 2),
+    ]
+    df = spark.createDataFrame(data, ["term", "period", "value"])
+
+    (
+        df.write.format("delta")
+        .mode("overwrite")
+        .partitionBy("period")
+        .save(path)
+    )
+
+    spark.sql(
+        f"CREATE TABLE IF NOT EXISTS {table_name} USING DELTA LOCATION '{path}'"
+    )
+    spark.sql(f"OPTIMIZE {table_name} ZORDER BY (term)")
+
+
+def main() -> None:
+    """Create curated and features tables using local paths."""
+    create_table("curated", "s3://example-bucket/curated")
+    create_table("features", "s3://example-bucket/features")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/register_schema.py
+++ b/scripts/register_schema.py
@@ -1,0 +1,51 @@
+"""Register Avro schemas with Confluent Schema Registry."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Optional, Tuple
+
+import requests
+
+
+def register_schema(
+    subject: str,
+    schema_path: str,
+    registry_url: str,
+    auth: Optional[Tuple[str, str]] = None,
+) -> dict:
+    """Register a schema file under the given subject.
+
+    Parameters
+    ----------
+    subject:
+        Schema Registry subject name.
+    schema_path:
+        Path to the Avro schema file (.avsc).
+    registry_url:
+        Base URL for the Schema Registry service.
+    auth:
+        Optional tuple with (username, password) for basic auth.
+    """
+    schema_str = Path(schema_path).read_text()
+    payload = {"schema": schema_str}
+    response = requests.post(
+        f"{registry_url.rstrip('/')}/subjects/{subject}/versions",
+        headers={"Content-Type": "application/vnd.schemaregistry.v1+json"},
+        data=json.dumps(payload),
+        auth=auth,
+        timeout=10,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def main() -> None:
+    """Example usage registering curated and features schemas."""
+    registry_url = "https://schema-registry.example.com"
+    register_schema("curated-value", "schemas/curated.avsc", registry_url)
+    register_schema("features-value", "schemas/features.avsc", registry_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,112 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "s3_bucket" {
+  description = "S3 bucket for data lake storage"
+  type        = string
+  default     = "example-bucket"
+}
+
+resource "aws_glue_catalog_database" "curated" {
+  name = "curated"
+}
+
+resource "aws_glue_catalog_database" "features" {
+  name = "features"
+}
+
+resource "aws_glue_catalog_table" "curated" {
+  name          = "curated"
+  database_name = aws_glue_catalog_database.curated.name
+  table_type    = "EXTERNAL_TABLE"
+  parameters = {
+    classification = "delta"
+  }
+  storage_descriptor {
+    location      = "s3://${var.s3_bucket}/curated"
+    input_format  = "io.delta.sql.DeltaInputFormat"
+    output_format = "io.delta.sql.DeltaOutputFormat"
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+  }
+  partition_keys {
+    name = "period"
+    type = "string"
+  }
+}
+
+resource "aws_glue_catalog_table" "features" {
+  name          = "features"
+  database_name = aws_glue_catalog_database.features.name
+  table_type    = "EXTERNAL_TABLE"
+  parameters = {
+    classification = "delta"
+  }
+  storage_descriptor {
+    location      = "s3://${var.s3_bucket}/features"
+    input_format  = "io.delta.sql.DeltaInputFormat"
+    output_format = "io.delta.sql.DeltaOutputFormat"
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe"
+    }
+  }
+  partition_keys {
+    name = "period"
+    type = "string"
+  }
+}
+
+resource "aws_iam_role" "glue" {
+  name = "glue-minimal-role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "glue.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "glue" {
+  name = "glue-minimal-policy"
+  role = aws_iam_role.glue.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["s3:ListBucket"]
+        Resource = "arn:aws:s3:::${var.s3_bucket}"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["s3:GetObject", "s3:PutObject"]
+        Resource = "arn:aws:s3:::${var.s3_bucket}/*"
+      },
+      {
+        Effect   = "Allow"
+        Action   = ["glue:*"]
+        Resource = "*"
+      }
+    ]
+  })
+}


### PR DESCRIPTION
## Summary
- create sample Delta Lake writer with period partitioning and Z-Ordering by term
- add script to register Avro schemas in Confluent Schema Registry
- provision Glue databases, tables, and minimal IAM role via Terraform

## Testing
- `python -m py_compile scripts/delta_setup.py scripts/register_schema.py`
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_68b128c8978c832da6a00ab1c2ac19c1