### PR TITLE
Add pluggable vector store module with API and Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# infodir
+# Vector Store Evaluation
+
+This repository evaluates **Milvus**, **Weaviate** and **PostgreSQL + pgvector** as
+vector database options. A small abstraction layer in `vector_store/` exposes a
+common API which is served through FastAPI for indexing and querying
+embeddings.
+
+## Usage
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Start the service (defaults to Weaviate backend):
+
+```bash
+uvicorn api:app --reload
+```
+
+Select the backend by setting the `VECTOR_STORE` environment variable to one of
+`milvus`, `weaviate` or `pgvector`.
+
+## Terraform
+
+The `terraform/` directory contains a sample configuration for provisioning a
+managed Weaviate cluster with configurable replication and shard counts.
+
+## Evaluation
+
+- **Milvus** – high performance, standalone vector database with IVF indexes.
+- **Weaviate** – cloud service with built-in semantic search capabilities.
+- **Postgres + pgvector** – leverages existing Postgres deployments and SQL.

--- a/api.py
+++ b/api.py
@@ -1,0 +1,43 @@
+"""Simple API exposing indexing and querying endpoints."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from vector_store import VectorStore, get_vector_store
+
+STORE_KIND = os.getenv("VECTOR_STORE", "weaviate")
+store: VectorStore = get_vector_store(STORE_KIND)
+
+app = FastAPI()
+
+
+class IndexRequest(BaseModel):
+    id: str
+    vector: List[float]
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class QueryRequest(BaseModel):
+    vector: List[float]
+    top_k: int = 5
+
+
+@app.post("/index")
+def index(req: IndexRequest) -> Dict[str, str]:
+    store.index_embedding(req.id, req.vector, req.metadata)
+    return {"status": "ok"}
+
+
+@app.post("/query")
+def query(req: QueryRequest) -> Dict[str, Any]:
+    results = store.query_embedding(req.vector, req.top_k)
+    return {
+        "results": [
+            {"id": ident, "score": score, "metadata": meta} for ident, score, meta in results
+        ]
+    }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+pymilvus
+weaviate-client
+psycopg2-binary

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_providers {
+    weaviate = {
+      source  = "semi-technologies/weaviate"
+      version = "~> 0.8"
+    }
+  }
+}
+
+provider "weaviate" {
+  # Authentication via WEAVIATE_API_KEY environment variable
+}
+
+resource "weaviate_cluster" "this" {
+  name     = var.name
+  tier     = var.tier
+  replicas = var.replicas
+  shards   = var.shards
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,23 @@
+variable "name" {
+  description = "Cluster name"
+  type        = string
+  default     = "vector-store"
+}
+
+variable "tier" {
+  description = "Service tier"
+  type        = string
+  default     = "sandbox"
+}
+
+variable "replicas" {
+  description = "Number of replicas"
+  type        = number
+  default     = 1
+}
+
+variable "shards" {
+  description = "Number of shards per class"
+  type        = number
+  default     = 1
+}

--- a/vector_store/__init__.py
+++ b/vector_store/__init__.py
@@ -1,0 +1,26 @@
+"""Vector store factory and exports."""
+
+from .base import VectorStore
+from .milvus_store import MilvusVectorStore
+from .weaviate_store import WeaviateVectorStore
+from .pgvector_store import PGVectorStore
+
+
+def get_vector_store(kind: str, **kwargs) -> VectorStore:
+    """Factory for vector store implementations."""
+    kind = kind.lower()
+    if kind == "milvus":
+        return MilvusVectorStore(**kwargs)
+    if kind == "weaviate":
+        return WeaviateVectorStore(**kwargs)
+    if kind in {"pgvector", "postgres"}:
+        return PGVectorStore(**kwargs)
+    raise ValueError(f"Unknown vector store kind: {kind}")
+
+__all__ = [
+    "VectorStore",
+    "MilvusVectorStore",
+    "WeaviateVectorStore",
+    "PGVectorStore",
+    "get_vector_store",
+]

--- a/vector_store/base.py
+++ b/vector_store/base.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Abstract base class for vector stores.
+
+Defines the minimal API required for indexing and querying vectors.
+"""
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class VectorStore(ABC):
+    """Interface for vector storage backends."""
+
+    @abstractmethod
+    def index_embedding(
+        self, identifier: str, vector: List[float], metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        """Index a single embedding.
+
+        Parameters
+        ----------
+        identifier:
+            Unique identifier for the vector.
+        vector:
+            Embedding values.
+        metadata:
+            Optional associated metadata.
+        """
+
+    @abstractmethod
+    def query_embedding(
+        self, vector: List[float], top_k: int = 5
+    ) -> List[Tuple[str, float, Dict[str, Any]]]:
+        """Query the most similar embeddings.
+
+        Returns a list of tuples ``(id, score, metadata)``.
+        """

--- a/vector_store/milvus_store.py
+++ b/vector_store/milvus_store.py
@@ -1,0 +1,57 @@
+"""Milvus implementation of :class:`VectorStore`."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+from pymilvus import Collection, CollectionSchema, DataType, FieldSchema, connections
+
+from .base import VectorStore
+
+
+class MilvusVectorStore(VectorStore):
+    """Store backed by a Milvus collection.
+
+    Parameters
+    ----------
+    host, port:
+        Milvus connection parameters.
+    collection:
+        Collection name to use.
+    dim:
+        Dimensionality of the embeddings.
+    """
+
+    def __init__(self, host: str = "localhost", port: str = "19530", collection: str = "embeddings", dim: int = 768):
+        connections.connect(host=host, port=port)
+        self.collection_name = collection
+        self.dim = dim
+        if collection not in connections.get_connection().list_collections():
+            fields = [
+                FieldSchema(name="id", dtype=DataType.VARCHAR, is_primary=True, max_length=64),
+                FieldSchema(name="vector", dtype=DataType.FLOAT_VECTOR, dim=dim),
+                FieldSchema(name="metadata", dtype=DataType.JSON, default={}),
+            ]
+            schema = CollectionSchema(fields, description="vector store")
+            self.collection = Collection(name=collection, schema=schema)
+            self.collection.create_index("vector", {"index_type": "IVF_FLAT", "metric_type": "L2", "params": {"nlist": 1024}})
+        else:
+            self.collection = Collection(collection)
+
+    def index_embedding(
+        self, identifier: str, vector: List[float], metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        data = [[identifier], [vector], [metadata or {}]]
+        self.collection.insert(data)
+        self.collection.flush()
+
+    def query_embedding(
+        self, vector: List[float], top_k: int = 5
+    ) -> List[Tuple[str, float, Dict[str, Any]]]:
+        search_params = {"metric_type": "L2", "params": {"nprobe": 10}}
+        results = self.collection.search([vector], "vector", search_params, top_k=top_k, output_fields=["metadata"])
+        out: List[Tuple[str, float, Dict[str, Any]]] = []
+        for hit in results[0]:
+            out.append((hit.id, float(hit.distance), json.loads(hit.entity.get("metadata", {}))))
+        return out

--- a/vector_store/pgvector_store.py
+++ b/vector_store/pgvector_store.py
@@ -1,0 +1,62 @@
+"""PostgreSQL + pgvector implementation of :class:`VectorStore`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import psycopg2
+from psycopg2.extras import Json
+
+from .base import VectorStore
+
+
+class PGVectorStore(VectorStore):
+    """Store backed by PostgreSQL with the pgvector extension."""
+
+    def __init__(self, dsn: str, table: str = "embeddings", dim: int = 768):
+        self.conn = psycopg2.connect(dsn)
+        self.table = table
+        self.dim = dim
+        with self.conn, self.conn.cursor() as cur:
+            cur.execute("CREATE EXTENSION IF NOT EXISTS vector")
+            cur.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {table} (
+                    id TEXT PRIMARY KEY,
+                    embedding VECTOR({dim}),
+                    metadata JSONB
+                )
+                """
+            )
+            cur.execute(
+                f"""
+                CREATE INDEX IF NOT EXISTS {table}_embedding_idx
+                ON {table} USING ivfflat (embedding vector_l2_ops)
+                WITH (lists = 100)
+                """
+            )
+
+    def index_embedding(
+        self, identifier: str, vector: List[float], metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        with self.conn, self.conn.cursor() as cur:
+            cur.execute(
+                f"""
+                INSERT INTO {self.table} (id, embedding, metadata)
+                VALUES (%s, %s, %s)
+                ON CONFLICT (id) DO UPDATE
+                SET embedding = EXCLUDED.embedding,
+                    metadata = EXCLUDED.metadata
+                """,
+                (identifier, vector, Json(metadata or {})),
+            )
+
+    def query_embedding(
+        self, vector: List[float], top_k: int = 5
+    ) -> List[Tuple[str, float, Dict[str, Any]]]:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"SELECT id, embedding <-> %s AS distance, metadata FROM {self.table} ORDER BY distance LIMIT %s",
+                (vector, top_k),
+            )
+            return [(row[0], float(row[1]), row[2] or {}) for row in cur.fetchall()]

--- a/vector_store/weaviate_store.py
+++ b/vector_store/weaviate_store.py
@@ -1,0 +1,54 @@
+"""Weaviate implementation of :class:`VectorStore`."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Tuple
+
+import weaviate
+
+from .base import VectorStore
+
+
+class WeaviateVectorStore(VectorStore):
+    """Store backed by a Weaviate instance."""
+
+    def __init__(self, url: str = "http://localhost:8080", class_name: str = "Document"):
+        self.client = weaviate.Client(url)
+        self.class_name = class_name
+        if not self.client.schema.contains({"class": class_name}):
+            class_obj = {
+                "class": class_name,
+                "vectorizer": "none",
+                "properties": [
+                    {"name": "content", "dataType": ["text"]},
+                ],
+            }
+            self.client.schema.create_class(class_obj)
+
+    def index_embedding(
+        self, identifier: str, vector: List[float], metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        data = metadata or {}
+        data["id"] = identifier
+        self.client.data_object.create(data, class_name=self.class_name, vector=vector)
+
+    def query_embedding(
+        self, vector: List[float], top_k: int = 5
+    ) -> List[Tuple[str, float, Dict[str, Any]]]:
+        result = (
+            self.client.query.get(self.class_name, ["content"])
+            .with_near_vector({"vector": vector})
+            .with_limit(top_k)
+            .with_additional(["id", "distance"])
+            .do()
+        )
+        hits = []
+        for obj in result.get("data", {}).get("Get", {}).get(self.class_name, []):
+            hits.append(
+                (
+                    obj["_additional"]["id"],
+                    float(obj["_additional"]["distance"]),
+                    {"content": obj.get("content")},
+                )
+            )
+        return hits


### PR DESCRIPTION
## Summary
- add `vector_store` abstraction with Milvus, Weaviate and Postgres+pgvector backends
- expose FastAPI `/index` and `/query` endpoints for embeddings
- include Terraform example with configurable replicas and shards
- document evaluation and usage instructions

## Testing
- `python -m py_compile $(find . -name '*.py')`
- `terraform -chdir=terraform init -backend=false` *(fails: provider not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b128d53d34832d873704f863940561